### PR TITLE
Don't import legacy test users for now

### DIFF
--- a/scripts/load_test_data.sh
+++ b/scripts/load_test_data.sh
@@ -40,7 +40,8 @@ function system_params {
 }
 
 function postgres_test_data {
-    psql --single-transaction -h $PG_HOST -U $POSTGRES_USERNAME -d $POSTGRES_NAME -f "$PROJECT_DIR/scripts/database/pg/populate-users.sql" --port $PG_PORT
+    # Don't import this test users for now.
+    #psql --single-transaction -h $PG_HOST -U $POSTGRES_USERNAME -d $POSTGRES_NAME -f "$PROJECT_DIR/scripts/database/pg/populate-users.sql" --port $PG_PORT
 }
 
 function delete_elasticsearch_index {


### PR DESCRIPTION
@dberesford do you agree with this change for the moment? This users are not used for now. We only use the admin@example.com and manager@example.com which are added by some other script in this service. 
