### PR TITLE
fix: quick fix for tests not to timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "npm run lint && bash -c 'source ./config/development.env; ./node_modules/.bin/lab --ignore __core-js_shared__ --flat --threshold 50 -r html -o ./coverage/coverage.html -r lcov -o ./coverage/lcov.info -r json -o ./coverage/coverage.json -r lab-quieter-reporter -o stdout'",
+    "test": "npm run lint && bash -c 'source ./config/development.env; ./node_modules/.bin/lab --ignore __core-js_shared__ --flat --threshold 50 -r html -o ./coverage/coverage.html -r lcov -o ./coverage/lcov.info -r json -o ./coverage/coverage.json -r lab-quieter-reporter -o stdout -m 5000'",
     "covrep": "bash test/covrep.sh",
     "lint": "./node_modules/.bin/semistandard *.js config/config.js"
   },


### PR DESCRIPTION
The proper solution is probably in splitting out `cmd_register` on `users.js` as suggested by @mcdonnelldean so it doesn't timeout.
He suggested that the task fires `done` right away before it goes off and does more things, therefore acknowledging the fact that it received the message, then doing whatever it has to and after that sending a registered message indicating the fact that it finished.
My knowledge on seneca is very limited but somebody that knows more about it would probably be able to take this on and provide a proper fix for it.