### PR TITLE
Specify the child profile id for is-parent-of

### DIFF
--- a/lib/users/is-parent-of.js
+++ b/lib/users/is-parent-of.js
@@ -10,6 +10,7 @@ function isParentOf (args, cb) {
   if (_.isUndefined(childrenId) && args.params.profile) childrenId = args.params.profile.userId;
   if (_.isUndefined(childrenId) && args.params.query) childrenId = args.params.query.userId;
   if (_.isUndefined(childrenId) && args.params.profileId) childrenProfileId = args.params.profileId;
+  if (_.isUndefined(childrenId) && args.params.profile) childrenProfileId = args.params.profile.id;
   if (_.isUndefined(childrenId) && args.params.id) childrenId = args.params.id;
   // Used by invite-parent-guardian
   if (_.isUndefined(childrenId) && args.params.data) childrenId = args.params.data.childId;


### PR DESCRIPTION
Since removal of the userId, we needed a new reference