### PR TITLE
Add profilePassword as sensitive data field

### DIFF
--- a/lib/controllers/users/load.js
+++ b/lib/controllers/users/load.js
@@ -10,7 +10,7 @@ var _ = require('lodash');
 function cmd_load (args, done) {
   var seneca = this;
   var ENTITY_NS = 'sys/user';
-  var sensitiveData = ['lmsId', 'pass', 'salt'];
+  var sensitiveData = ['lmsId', 'pass', 'salt', 'profilePassword'];
   seneca.make(ENTITY_NS).load$(args.id, function (err, user) {
     return done(err, _.omit(user, sensitiveData));
   });

--- a/users.js
+++ b/users.js
@@ -256,6 +256,7 @@ module.exports = function (options) {
     delete user.active;
     delete user.accounts;
     delete user.confirmcode;
+    delete user.profilePassword;
     return user;
   }
 


### PR DESCRIPTION
Add the new profilePassword user column as sensitive data field so that it is not returned in user object.

The exposure I saw was that as a champion, when viewing users of my dojo, the `get-parents-for-user` endpoint brought back full user objects for parents including the profilePassword hash.