### PR TITLE
Rename profile_id column to raspberry_id

### DIFF
--- a/scripts/database/pg/migrations/029.do.rename-profile-id-raspberry.sql
+++ b/scripts/database/pg/migrations/029.do.rename-profile-id-raspberry.sql
@@ -1,0 +1,9 @@
+DO $$ 
+    BEGIN
+        BEGIN
+            ALTER TABLE sys_user RENAME COLUMN profile_id TO raspberry_id;
+        EXCEPTION
+            WHEN invalid_column_reference THEN RAISE NOTICE 'column profile_id not found.';
+        END;
+    END;
+$$

--- a/users.js
+++ b/users.js
@@ -24,7 +24,7 @@ module.exports = function (options) {
   seneca.add({role: plugin, cmd: 'register'}, cmd_register);
   seneca.add({role: plugin, cmd: 'promote'}, cmd_promote);
   seneca.add({role: plugin, cmd: 'get_users_by_emails'}, cmd_get_users_by_emails);
-  seneca.add({role: plugin, cmd: 'get_user_by_profile_id'}, cmd_get_user_by_profile_id);
+  seneca.add({role: plugin, cmd: 'get_user_by_raspberry_id'}, cmd_get_user_by_raspberry_id);
   seneca.add({role: plugin, cmd: 'update'}, cmd_update);
   seneca.add({role: plugin, cmd: 'get_init_user_types'}, cmd_get_init_user_types);
   seneca.add({role: plugin, cmd: 'is_champion'}, cmd_is_champion);
@@ -309,11 +309,11 @@ module.exports = function (options) {
     }
   }
 
-  function cmd_get_user_by_profile_id (args, done) {
+  function cmd_get_user_by_raspberry_id (args, done) {
     var seneca = this;
     var query = {};
 
-    query.profileId = args.profileId;
+    query.raspberryId = args.raspberryId;
     query.limit$ = query.limit$ ? query.limit$ : 1;
 
     seneca.make(ENTITY_NS).list$(query, function (err, users) {


### PR DESCRIPTION
Renamed the profile_id column recently added for rpi integration, to raspberry_id.

There is a profile table that has it's own id which make my intial name choice a super confusing one! There are also existing places in code where profileId is used in reference to the zen profile.id.

Needs to be merged alongside https://github.com/CoderDojo/cp-zen-platform/pull/1390