### PR TITLE
Block raspberry linked accounts from logging in with pword

### DIFF
--- a/users.js
+++ b/users.js
@@ -547,12 +547,16 @@ module.exports = function (options) {
       if (err) return done(err);
       if (!loginResponse.ok || !loginResponse.user) return done(null, loginResponse);
 
+      if (loginResponse.user.raspberryId && !args.auto) {
+        return done(null, {ok: false, login: null, user: null, why: 'raspberry-linked'});
+      }
+
       const handlers = [
         verifyPermissions,
         recordLogin
       ];
 
-      if (!loginResponse.user.profilePassword) {
+      if (!args.auto && !loginResponse.user.profilePassword) {
         handlers.push(updateProfilePassword);
       }
 


### PR DESCRIPTION
- Block raspberry linked accounts from logging in with pword
    - Cookie setting etc. is done on zen platform side so will be prevented by sending ok false and no user in response to zen platform
- only sync up profile Password if it's not a raspberrypi prompted login